### PR TITLE
Fixes arity problem introduced by rails 3.2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,1 +1,1 @@
-eval File.read('Gemfile.rails-3.1')
+eval File.read('Gemfile.rails-3.2')

--- a/Gemfile.rails-3.2
+++ b/Gemfile.rails-3.2
@@ -6,4 +6,4 @@ deps = spec.dependencies.map { |dep| {:name => dep.name, :version => dep.require
 deps.reject! { |dep| dep[:name] =~ /activerecord/ }
 deps.each    { |dep| gem dep[:name], dep[:version] }
 
-gem 'activerecord', '3.2.0.rc1'
+gem 'activerecord', '3.2.5'

--- a/lib/grouped_scope/arish/relation/predicate_builer.rb
+++ b/lib/grouped_scope/arish/relation/predicate_builer.rb
@@ -10,12 +10,12 @@ module GroupedScope
       
       module ClassMethods
         
-        def build_from_hash_with_grouped_scope(engine, attributes, default_table)
+        def build_from_hash_with_grouped_scope(engine, attributes, default_table, check_column = true)
           attributes.select{ |column, value| GroupedScope::SelfGroupping === value }.each do |column_value|
             column, value = column_value
             attributes[column] = value.arel_table[column.to_s].in(value.ids_sql)
           end
-          build_from_hash_without_grouped_scope(engine, attributes, default_table)
+          build_from_hash_without_grouped_scope(engine, attributes, default_table, check_column)
         end
         
       end


### PR DESCRIPTION
Rails 3.2.5 changed the arity of a method you're alias_method_chaining. This patch corrects that. Sadly, this doesn't seem to be exercised by the test suite anywhere, but I can verify it was broken, and now works, when integrated with a real-world app. :)
